### PR TITLE
Return only the ca instead of ca-ra cert for the first step of scep enrollment

### DIFF
--- a/example-server/application.rb
+++ b/example-server/application.rb
@@ -28,8 +28,7 @@ webrick_options = {
         :SSLCertName        => [ [ "CN",WEBrick::Utils::getservername ] ]
 }
 
-class NBServer  < Sinatra::Base
-
+class MyServer < Sinatra::Base
 
   get '/' do
     '<a href="/enroll">Enroll</a>'

--- a/lib/ios-cert-enrollment/sign.rb
+++ b/lib/ios-cert-enrollment/sign.rb
@@ -9,10 +9,7 @@ module IOSCertEnrollment
        
     class << self    
       def registration_authority    
-        scep_certs = OpenSSL::PKCS7.new()
-        scep_certs.type="signed"
-        scep_certs.certificates=[SSL.certificate,SSL.certificate]
-        return Certificate.new(scep_certs.to_der, "application/x-x509-ca-ra-cert")
+        return Certificate.new(SSL.certificate.to_der, "application/x-x509-ca-cert")
       end
       
       def certificate_authority_caps


### PR DESCRIPTION
I'm not sure why this is needed, but sending back duplicate certs with the ca-ra mime type wasn't working.  This might deserve more investigation if someone is implementing this with a true CA instead of just issuing certs off a self-signed/normal cert.  

Also fixed a small typo in the example app that prevented it from running out of the box. 
