### PR TITLE
add support for signing with intermediate certificates

### DIFF
--- a/lib/ios-cert-enrollment/configuration.rb
+++ b/lib/ios-cert-enrollment/configuration.rb
@@ -6,6 +6,7 @@ module IOSCertEnrollment
     VALID_OPTIONS_KEYS = [
       :ssl_certificate_path,
       :ssl_key_path,
+      :intermediate_certificate_paths,
       :base_url,
       :identifier,
       :display_name,

--- a/lib/ios-cert-enrollment/profile.rb
+++ b/lib/ios-cert-enrollment/profile.rb
@@ -100,7 +100,7 @@ module IOSCertEnrollment
     
     
     def sign
-      signed_profile = OpenSSL::PKCS7.sign(SSL.certificate, SSL.key,  self.payload, [], OpenSSL::PKCS7::BINARY)
+      signed_profile = OpenSSL::PKCS7.sign(SSL.certificate, SSL.key,  self.payload, SSL.intermediate_certificates, OpenSSL::PKCS7::BINARY)
       return Certificate.new(signed_profile.to_der, "application/x-apple-aspen-config")        
       
     end

--- a/lib/ios-cert-enrollment/ssl.rb
+++ b/lib/ios-cert-enrollment/ssl.rb
@@ -1,6 +1,6 @@
 module IOSCertEnrollment
   module SSL
-    @@key, @@certificate = nil
+    @@key, @@certificate, @@intermediate_certificates = nil
     class << self    
       def key
         return @@key if @@key
@@ -10,6 +10,12 @@ module IOSCertEnrollment
       def certificate
         return @@certificate if @@certificate
         return @@certificate = OpenSSL::X509::Certificate.new(File.read(IOSCertEnrollment.ssl_certificate_path))
+      end
+
+      def intermediate_certificates
+        return @@intermediate_certificates if @@intermediate_certificates
+        certificate_paths = IOSCertEnrollment.intermediate_certificate_paths || []
+        @@intermediate_certificates = certificate_paths.collect{|x| OpenSSL::X509::Certificate.new(File.read(x))}
       end
     end
     


### PR DESCRIPTION
Since iOS 6, apple requires you to sign the payloads with the enter certificate chain (including the root) in order to show the green "Verified" tag on the install profile screen.

This pull request adds a configuration option that optionally includes an unlimited number of intermediate  in the signatures. 
